### PR TITLE
Fixed Vmware execution

### DIFF
--- a/must-gather/mustgather.pl
+++ b/must-gather/mustgather.pl
@@ -223,6 +223,7 @@ print "Starting must-gather for product: $product\n" if $verbose;
         'sp-client-sap-hana' => "$FindBin::Bin/sp-client-sap-hana/mustgather.pl",
         'sp-client-domino' => "$FindBin::Bin/sp-client-domino/mustgather.pl",
         'sp-client-exchange' => "$FindBin::Bin/sp-client-exchange/mustgather.pl",
+        'sp-client-vmware' => "$FindBin::Bin/sp-client-vmware/mustgather.pl",
         # Add more products as developed
     );
 


### PR DESCRIPTION
While attempting to execute the VMware must-gather, the following issue was observed:
The execution entry for the VMware product was missing from the product-to-script mapping. As a result, the VMware must-gather script was not being invoked correctly, causing the execution failure.
<img width="3134" height="236" alt="image" src="https://github.com/user-attachments/assets/4e2871fc-5c20-4319-b85b-1fcb14bc2edb" />
<img width="1664" height="542" alt="image" src="https://github.com/user-attachments/assets/b625d423-4780-4702-8927-501d02fe33e0" />

The issue has been resolved by adding the missing execution mapping for the VMware product.
With this change, the VMware must-gather script is now correctly referenced and executed.
<img width="1720" height="924" alt="image" src="https://github.com/user-attachments/assets/81451342-a207-488f-8a61-64f7b935cd4c" />

