### PR TITLE
Added modules for objectAgent and RetentionSet

### DIFF
--- a/must-gather/sp-server/collector/config.pl
+++ b/must-gather/sp-server/collector/config.pl
@@ -111,15 +111,17 @@ sub run_cmd {
 }
 
 # -----------------------------
-# Define dsm administrative client queries
+# Define dsm administrative  nmclient queries
 # -----------------------------
 my %server_queries = (
-    "actlog.txt"    => "query actlog begindate=today-7",
     "system.txt"    => "query system",
     "policies.txt"  => "q policy f=d",
     "nodes.txt"     => "q node f=d",
     "occupancy.txt" => "q occ",
     "policyset.txt" => "q policyset",
+    "backup_copygroups.txt"  => "q copygroup * * * standard type=backup f=d",
+    "archive_copygroups.txt" => "q copygroup * * * standard type=archive f=d",
+    "events.txt"    => "q event * * begindate=-7 enddate=-0",
 );
 
 # -----------------------------
@@ -131,6 +133,10 @@ foreach my $file (sort keys %server_queries) {
     my $cmd = qq{$quoted_dsm -id=$adminid -password=$password -optfile=$quoted_opt "$query"};
     run_cmd($cmd, $outfile);
 }
+
+my $actoutfile = "$output_dir/actlog.txt";
+my $act_cmd = qq{$quoted_dsm -comma -id=$adminid -password=$password -optfile=$quoted_opt "query actlog begindate=today-7"};
+run_cmd($act_cmd, $actoutfile);
 
 # -----------------------------
 # Collect server instance-specific files

--- a/must-gather/sp-server/collector/objectAgent.pl
+++ b/must-gather/sp-server/collector/objectAgent.pl
@@ -1,0 +1,342 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Getopt::Long;
+use FindBin;
+use File::Path qw(make_path);
+use File::Copy qw(copy);
+use lib "$FindBin::Bin/../../common/modules";
+use env;
+use utils;
+
+# -----------------------------
+# Parameters / CLI optfile
+# -----------------------------
+my ($output_dir, $verbose, $optfile);
+GetOptions(
+    "output-dir|o=s" => \$output_dir,
+    "verbose|v"      => \$verbose,
+    "optfile=s"       => \$optfile,
+) or die "Invalid arguments. Run with --help for usage.\n";
+
+die "Error: --output-dir is required\n" unless $output_dir;
+
+# SECURITY: Get credentials from ENVIRONMENT only
+my $adminid  = $ENV{MUSTGATHER_ADMINID}  || '';
+my $password = $ENV{MUSTGATHER_PASSWORD} || '';
+
+# -----------------------------
+# Prepare output directory
+# -----------------------------
+$output_dir = "$output_dir/objectagent";
+make_path($output_dir) unless -d $output_dir;
+
+# -----------------------------
+# Error log
+# -----------------------------
+my $error_log = "$output_dir/script.log";
+open(my $errfh, '>', $error_log) or die "Cannot open $error_log: $!";
+
+# -----------------------------
+# Detect BA client path
+# -----------------------------
+my $base_path = env::get_ba_base_path();
+unless ($base_path) {
+    print $errfh "BA client base path not found.\n";
+    close($errfh);
+    die "BA client base path not found. Exiting.\n";
+}
+
+# -----------------------------
+# Locate DSMADMC binary
+# -----------------------------
+my $dsmadmc = "$base_path/dsmadmc";
+$dsmadmc .= ".exe" if $^O =~ /MSWin32/;
+unless (-x $dsmadmc) {
+    print $errfh "dsmadmc not found at $dsmadmc\n";
+    close($errfh);
+    die "dsmadmc not found at $dsmadmc\n";
+}
+
+# -----------------------------
+# DSM Option File Path
+# -----------------------------
+my $opt_file;
+if ($optfile) {
+    # User-specified option file
+    $opt_file = $optfile;
+} else {
+    $opt_file = "$base_path/dsm.opt";
+}
+
+# -----------------------------
+# Quote paths if they contain spaces
+# -----------------------------
+my $quoted_dsm = $dsmadmc =~ / / ? qq{"$dsmadmc"} : $dsmadmc;
+my $quoted_opt = $opt_file =~ / / ? qq{"$opt_file"} : $opt_file;
+
+# -----------------------------
+# Function to run a command safely
+# -----------------------------
+sub run_cmd {
+    my ($cmd, $outfile) = @_;
+
+    my $full_cmd;
+    if ($outfile) {
+        $full_cmd = qq{$cmd > "$outfile"};
+        $full_cmd .= " 2>&1" if $^O !~ /MSWin32/;  # redirect stderr on Unix
+    } else {
+        $full_cmd = $cmd;
+    }
+
+    print $errfh "Running: $full_cmd\n" if $verbose;
+
+    my $status = system($full_cmd);
+    $status >>= 8;
+    return $status;
+}
+
+# -----------------------------
+# Get Object Agent server name
+# -----------------------------
+my $objectagent_file = "$output_dir/objectagent_servers_raw.txt";
+my $objectagent_query = qq{$quoted_dsm -id=$adminid -password=$password -optfile=$quoted_opt "SELECT SERVER_NAME, OBJECT_AGENT FROM SERVERS WHERE OBJECT_AGENT='Yes'"};
+run_cmd($objectagent_query, $objectagent_file);
+
+open(my $oaf, '<', $objectagent_file) or die "Cannot open $objectagent_file: $!";
+my $objectagent_server;
+while (<$oaf>) {
+    chomp;
+    # Skip blank lines
+    next if /^\s*$/;
+
+    # Skip known non-data lines
+    next if /^(IBM|Command|ANS\d+|Copyright|\(c\)|Return code|---|No match|Highest return code)/i;
+    next if /Session established with server/i;
+    next if /Server Version/i;
+    next if /Server date\/time/i;
+    next if /^ANS\d+/;
+    next if /ANR\d+E.*No match found/i;
+    # Skip column header lines
+    next if /SERVER_NAME|OBJECT_AGENT/i;
+    next if /^\s*-+\s*$/;
+
+    # Trim whitespace
+    s/^\s+|\s+$//g;
+
+    # Extract server name (first column)
+    my ($server_name, $obj_agent) = split(/\s+/, $_, 2);
+    if ($server_name && !$objectagent_server) {
+        $objectagent_server = $server_name;
+        last;  # Only one Object Agent server
+    }
+}
+close($oaf);
+
+unless ($objectagent_server) {
+    print $errfh "No Object Agent server found (OBJECT_AGENT='Yes').\n";
+    if ($verbose) {
+        print "\n=== Object Agent Module Summary ===\n";
+        print "No Object Agent server detected.\n";
+        print "Check script.log for details.\n";
+    }
+    close($errfh);
+    exit(0);
+}
+
+print $errfh "Object Agent server detected: $objectagent_server\n" if $verbose;
+
+# -----------------------------
+# Get Object Client nodes
+# -----------------------------
+my $objectclient_file = "$output_dir/objectclient_nodes_raw.txt";
+my $objectclient_query = qq{$quoted_dsm -id=$adminid -password=$password -optfile=$quoted_opt "SELECT NODE_NAME, NODETYPE FROM NODES WHERE NODETYPE='OBJECTCLIENT'"};
+run_cmd($objectclient_query, $objectclient_file);
+
+open(my $ocf, '<', $objectclient_file) or die "Cannot open $objectclient_file: $!";
+my %objectclient_nodes;
+while (<$ocf>) {
+    chomp;
+    # Skip blank lines
+    next if /^\s*$/;
+
+    # Skip known non-data lines
+    next if /^(IBM|Command|ANS\d+|Copyright|\(c\)|Return code|---|No match|Highest return code)/i;
+    next if /Session established with server/i;
+    next if /Server Version/i;
+    next if /Server date\/time/i;
+    next if /^ANS\d+/;
+    next if /ANR\d+E.*No match found/i;
+    # Skip column header lines
+    next if /NODE_NAME|NODETYPE/i;
+    next if /^\s*-+\s*$/;
+
+    # Trim whitespace
+    s/^\s+|\s+$//g;
+
+    # Extract node name (first column)
+    my ($node_name, $nodetype) = split(/\s+/, $_, 2);
+    if ($node_name) {
+        $objectclient_nodes{$node_name} = 1;
+    }
+}
+close($ocf);
+
+my @objectclient_nodes = sort keys %objectclient_nodes;
+
+if (@objectclient_nodes) {
+    print $errfh "Object Client nodes detected: " . join(", ", @objectclient_nodes) . "\n" if $verbose;
+} else {
+    print $errfh "No Object Client nodes found (NODETYPE='OBJECTCLIENT').\n";
+}
+
+# -----------------------------
+# Define queries for Object Agent server
+# -----------------------------
+my %server_queries = (
+    "query_server_objectagent.txt" => "query server $objectagent_server f=d",
+);
+
+# -----------------------------
+# Run queries for Object Agent server
+# -----------------------------
+foreach my $file (sort keys %server_queries) {
+    my $query = $server_queries{$file};
+    my $outfile = "$output_dir/$file";
+    my $cmd = qq{$quoted_dsm -id=$adminid -password=$password -optfile=$quoted_opt "$query"};
+    run_cmd($cmd, $outfile);
+}
+
+# -----------------------------
+# Run queries for each Object Client node
+# -----------------------------
+my $qnode_dir = "$output_dir/qnode";
+make_path($qnode_dir) unless -d $qnode_dir;
+
+foreach my $node (@objectclient_nodes) {
+    my $outfile = "$qnode_dir/query_node_$node.txt";
+    my $cmd = qq{$quoted_dsm -id=$adminid -password=$password -optfile=$quoted_opt "QUERY NODE $node f=d"};
+    run_cmd($cmd, $outfile);
+}
+
+# -----------------------------
+# Get instance directory information
+# -----------------------------
+my $instance_info = env::get_sp_instance_info();
+my $instance_dir;
+
+if ($instance_info && $instance_info->{directory}) {
+    $instance_dir = $instance_info->{directory};
+    print $errfh "Instance directory detected: $instance_dir\n" if $verbose;
+} else {
+    print $errfh "Could not determine instance directory from env::get_sp_instance_info.\n";
+}
+
+# -----------------------------
+# Collect Object Agent files (protect.log and config)
+# -----------------------------
+my %collected_files;
+
+if ($instance_dir && -d $instance_dir && $objectagent_server) {
+    # Look for object agent directory using the server name
+    my $objectagent_path = "$instance_dir/$objectagent_server";
+    
+    if (-d $objectagent_path) {
+        print $errfh "Object Agent directory found: $objectagent_path\n" if $verbose;
+        
+        # Look for protect.log
+        my $protect_log = "$objectagent_path/protect.log";
+        if (-f $protect_log) {
+            my $dest = "$output_dir/protect.log";
+            if (copy($protect_log, $dest)) {
+                $collected_files{"protect.log"} = "Success";
+                print $errfh "Collected: $protect_log\n" if $verbose;
+            } else {
+                $collected_files{"protect.log"} = "Failed";
+                print $errfh "Failed to copy: $protect_log - $!\n";
+            }
+        } else {
+            print $errfh "protect.log not found at: $protect_log\n";
+            $collected_files{"protect.log"} = "Not Found";
+        }
+        
+        # Look for <object-name>.config
+        
+        my $config_file = "$objectagent_path/spObjectAgent_${objectagent_server}_1500.config";
+        if ($config_file =~ /spObjectAgent_\Q$objectagent_server\E_.*\.config$/i && -f $config_file) {
+        my $dest = "$output_dir/$objectagent_server.config";
+        if (copy($config_file, $dest)) {
+            $collected_files{"$objectagent_server.config"} = "Success";
+            print $errfh "Collected: $config_file\n" if $verbose;
+        } else {
+            $collected_files{"$objectagent_server.config"} = "Failed";
+             print $errfh "Failed to copy: $config_file - $!\n";
+        }
+        } else {
+            print $errfh "$objectagent_server.config not found at: $config_file\n";
+            $collected_files{"$objectagent_server.config"} = "Not Found";
+        }
+    } else {
+        print $errfh "Object Agent directory not found: $objectagent_path\n";
+        $collected_files{"Object Agent directory"} = "Not Found";
+    }
+}
+
+SKIP_FILES:
+
+# -----------------------------
+# Collect Object Agent process information
+# -----------------------------
+my $process_file = "$output_dir/objectagent_process.txt";
+if ($^O =~ /MSWin32/i) {
+    run_cmd("tasklist | findstr /i spObjectAgent", $process_file);
+} else {
+    run_cmd("ps -ef | grep spObjectAgent", $process_file);
+}
+
+# -----------------------------
+# Collect summary for all queries
+# -----------------------------
+my %summary;
+
+sub mark_summary {
+    my ($key, $file) = @_;
+    $summary{$key} = (-s $file) ? "Success" : "Failed";
+}
+
+# ---- Server queries
+foreach my $file (keys %server_queries) {
+    mark_summary($file, "$output_dir/$file");
+}
+
+# ---- Node queries
+foreach my $node (@objectclient_nodes) {
+    my $file = "$qnode_dir/query_node_$node.txt";
+    mark_summary("query_node_$node.txt", $file);
+}
+
+# ---- Process info
+mark_summary("objectagent_process.txt", $process_file);
+
+# ---- Collected files
+foreach my $file (keys %collected_files) {
+    $summary{$file} = $collected_files{$file};
+}
+
+# ---- Print summary when verbose
+if ($verbose) {
+    print "\n=== Object Agent Module Summary ===\n";
+    print "Object Agent Server: $objectagent_server\n";
+    print "Object Client Nodes: " . (@objectclient_nodes ? join(", ", @objectclient_nodes) : "None") . "\n";
+    print "\nQuery Results:\n";
+    foreach my $k (sort keys %summary) {
+        printf "  %-40s : %s\n", $k, $summary{$k};
+    }
+    print "\nObject Agent data collected in: $output_dir\n";
+    print "Check script.log for command failures.\n";
+}
+
+# -----------------------------
+# Done
+# -----------------------------
+close($errfh);

--- a/must-gather/sp-server/collector/retentionSet.pl
+++ b/must-gather/sp-server/collector/retentionSet.pl
@@ -1,0 +1,166 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use File::Path qw(make_path);
+use FindBin;
+use lib "$FindBin::Bin/../../common/modules";
+use env;
+use Getopt::Long;
+
+# -----------------------------
+# Parse arguments
+# -----------------------------
+my ($output_dir, $verbose, $optfile);
+GetOptions(
+    "output-dir|o=s"       => \$output_dir,
+    "verbose|v"            => \$verbose,
+    "optfile=s"            => \$optfile,
+) or die "Invalid arguments\n";
+
+die "Error: --output-dir is required\n" unless $output_dir;
+
+# -----------------------------
+# Retention Rule Input
+# -----------------------------
+my $retention_rulename;
+if (!$retention_rulename) {
+    print "Enter Retention Rule Name: ";
+    chomp($retention_rulename = <STDIN>);
+}
+
+die "Error: retention_rulename cannot be empty\n" unless $retention_rulename;
+
+# -----------------------------
+# Credentials (ENV)
+# -----------------------------
+my $adminid  = $ENV{MUSTGATHER_ADMINID}  || '';
+my $password = $ENV{MUSTGATHER_PASSWORD} || '';
+
+# -----------------------------
+# Prepare output directory
+# -----------------------------
+$output_dir = "$output_dir/retentionSet";
+make_path($output_dir) unless -d $output_dir;
+
+# -----------------------------
+# Error log setup
+# -----------------------------
+my $error_log = "$output_dir/script.log";
+open(my $errfh, '>', $error_log) or die "Cannot open $error_log: $!";
+
+# -----------------------------
+# Detect BA base path
+# -----------------------------
+my $base_path = env::get_ba_base_path();
+unless ($base_path) {
+    print $errfh "BA client base path not found\n";
+    close($errfh);
+    die "BA client base path not found\n";
+}
+
+# -----------------------------
+# Locate DSMADMC
+# -----------------------------
+my $os = $^O;
+my $dsmadmc;
+
+if ($os =~ /MSWin32/i) {
+    $dsmadmc = `where dsmadmc.exe 2>nul`;
+    chomp($dsmadmc);
+    $dsmadmc = "$base_path\\dsmadmc.exe" if !$dsmadmc;
+} else {
+    $dsmadmc = `which dsmadmc 2>/dev/null`;
+    chomp($dsmadmc);
+    $dsmadmc = "$base_path/dsmadmc" if !$dsmadmc;
+}
+
+unless ($dsmadmc && -x $dsmadmc) {
+    print $errfh "dsmadmc not found\n";
+    close($errfh);
+    die "dsmadmc not found\n";
+}
+
+# -----------------------------
+# Option file
+# -----------------------------
+my $opt_file = $optfile || "$base_path/dsm.opt";
+
+my $quoted_dsm = $dsmadmc =~ / / ? qq{"$dsmadmc"} : $dsmadmc;
+my $quoted_opt = $opt_file =~ / / ? qq{"$opt_file"} : $opt_file;
+
+# -----------------------------
+# Run command helper
+# -----------------------------
+sub run_cmd {
+    my ($cmd, $outfile) = @_;
+
+    my $full_cmd = qq{$cmd > "$outfile"};
+    $full_cmd .= " 2>&1" if $^O !~ /MSWin32/;
+
+    print $errfh "Running: $full_cmd\n" if $verbose;
+
+    my $status = system($full_cmd);
+    $status >>= 8;
+    return $status;
+}
+
+# -----------------------------
+# Define retention queries
+# -----------------------------
+my %retention_queries = (
+    "retset.out"            => "query retset",
+    "retrule.out"           => "query retrule f=d",
+    "qjob.out"              => "query job",
+    "qjobinterrupt.out"     => "query job status=interrupted",
+    "qjobterm.out"          => "query job status=terminated",
+    "qretsetcontent.out"    => "query retsetcontents retrulename=$retention_rulename f=d",
+);
+
+# -----------------------------
+# Execute queries
+# -----------------------------
+foreach my $file (sort keys %retention_queries) {
+    my $query = $retention_queries{$file};
+    my $outfile = "$output_dir/$file";
+
+    my $cmd = qq{$quoted_dsm -id=$adminid -password=$password -optfile=$quoted_opt "$query"};
+    run_cmd($cmd, $outfile);
+}
+
+# -----------------------------
+# Summary
+# -----------------------------
+close($errfh);
+
+my %summary;
+
+foreach my $file (keys %retention_queries) {
+    my $outfile = "$output_dir/$file";
+    $summary{$file} = (-s $outfile) ? "Success" : "Failed";
+}
+
+if ($verbose) {
+    print "\n=== RetentionSet Module Summary ===\n";
+    foreach my $file (sort keys %summary) {
+        printf "  %-25s : %s\n", $file, $summary{$file};
+    }
+    print "Collected files saved in: $output_dir\n";
+    print "Check script.log for details\n";
+}
+
+# -----------------------------
+# Exit status
+# -----------------------------
+my $success = grep { $_ eq "Success" } values %summary;
+my $total   = scalar keys %summary;
+
+my $module_status;
+if ($success == $total) {
+    $module_status = "Success";
+} elsif ($success == 0) {
+    $module_status = "Failed";
+} else {
+    $module_status = "Partial";
+}
+
+exit($module_status eq "Success" ? 0 : $module_status eq "Partial" ? 2 : 1);

--- a/must-gather/sp-server/mustgather.pl
+++ b/must-gather/sp-server/mustgather.pl
@@ -49,7 +49,7 @@ my $os = env::_os();
 # Module List (ensure config runs first, no duplicates)
 # ----------------------------------
 my @default_modules = qw(config network system);  # Always run config
-my @requested_modules = $modules ? split /,/, $modules : qw(system network server tape replication stgpool dbbackup tiering install-upgrade librarysharing oc dbreorganisation expiration lanfree server-crash dbcorruption nas-ndmp);
+my @requested_modules = $modules ? split /,/, $modules : qw(system network server tape replication stgpool dbbackup tiering install-upgrade librarysharing oc dbreorganisation expiration lanfree server-crash dbcorruption nas-ndmp objectAgent retentionSet);
 
 # Combine and remove duplicates
 my %seen;
@@ -184,7 +184,7 @@ foreach my $module (@selected_modules) {
     my $exit_code = 1;
     my $script;
         # Check if SP server is running for modules that require it
-    if ($module =~ /^(config|tape|replication|stgpool|server|dbbackup|librarysharing|oc|tiering|dbreorganisation|expiration|lanfree|nas-ndmp|dbcorruption)$/) {
+    if ($module =~ /^(config|tape|replication|stgpool|server|dbbackup|librarysharing|oc|tiering|dbreorganisation|expiration|lanfree|nas-ndmp|dbcorruption|objectAgent|retentionSet)$/) {
         unless (env::is_sp_server_running()) {
             warn "Storage Protect Server is NOT running. Skipping $module module...\n";
             $module_status{$module} = "SKIPPED";
@@ -247,6 +247,12 @@ foreach my $module (@selected_modules) {
     elsif ($module eq "nas-ndmp"){
         $script = File::Spec->catfile($FindBin::Bin, "collector", "nas_ndmp.pl");
     }
+    elsif ($module eq "objectAgent"){
+        $script = File::Spec->catfile($FindBin::Bin, "collector", "objectAgent.pl");
+    }
+    elsif ($module eq "retentionSet"){
+        $script = File::Spec->catfile($FindBin::Bin, "collector", "retentionSet.pl");
+    }
     else {
         warn "Warning: Unknown module '$module'. Skipping...\n";
         $module_status{$module} = "SKIPPED";
@@ -261,7 +267,7 @@ foreach my $module (@selected_modules) {
     push @args, ("-s", $server_ip) if $module eq "network" && $server_ip;
     push @args, ("-p", $port) if $module eq "network" && $port;
     push @args, "-v" if $verbose;
-    push @args, ("--optfile",$optfile) if ($module eq "config" || $module eq "server" || $module eq "tape" || $module eq "replication" ||$module eq "stgpool" ||$module eq "dbbackup" || $module eq "tiering" || $module eq "librarysharing" || $module eq "oc" || $module eq "expiration" || $module eq "lanfree"  || $module eq "dbreorganisation") && $optfile;
+    push @args, ("--optfile",$optfile) if ($module eq "config" || $module eq "server" || $module eq "tape" || $module eq "replication" ||$module eq "stgpool" ||$module eq "dbbackup" || $module eq "tiering" || $module eq "librarysharing" || $module eq "oc" || $module eq "expiration" || $module eq "lanfree"  || $module eq "dbreorganisation"  || $module eq "objectAgent"  || $module eq "retentionSet") && $optfile;
     # Execute the script
     $exit_code = system(@args);
     $exit_code >>= 8;  # Normalize child exit code


### PR DESCRIPTION
This PR includes the following modules:
objectAgent
Technot referred: [https://www.ibm.com/support/pages/node/7256873](https://www.ibm.com/support/pages/node/7256873)
RetentionSet
Technote referred: [https://www.ibm.com/support/pages/node/7246836](https://www.ibm.com/support/pages/node/7246836)

Test results:
https://ibm.ent.box.com/folder/345820542752

Attaching screenshot of execution:
**objectAgent**:

Linux:
<img width="967" height="491" alt="image" src="https://github.com/user-attachments/assets/6fdc8ca4-d0ee-4b6e-90a5-7cd5f56cfd63" />

Aix:
<img width="789" height="463" alt="image" src="https://github.com/user-attachments/assets/d798e15d-6ba1-4a28-aeca-a67c931dae9e" />

Windows:
<img width="928" height="322" alt="image" src="https://github.com/user-attachments/assets/c1de1f03-d1a9-4a29-946c-38a5c14e8dd1" />

**RetentionSet**:

Linux:
<img width="979" height="504" alt="image" src="https://github.com/user-attachments/assets/353b4e3d-b46d-4eb9-b4fd-b85c9df33d10" />

Aix:
<img width="640" height="314" alt="image" src="https://github.com/user-attachments/assets/006bf8be-6af4-423c-aa20-30c052f377b3" />
