### PR TITLE
Added  must gather for HSM

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -11,16 +11,16 @@ The must-gather scripts are developed to collect diagnostic data across multiple
 | Storage Agent               | sp-server-sta               |
 | SP Client – Backup-Archive  | sp-client-ba                |
 | SP Client – Space Management| sp-client-space-mgmt        |
-| SP Client – HSM for Windows | sp-client-hsm               |
+| SP Client – HSM             | sp-client-hsm               |
 | SP4VE – VMware              | sp-client-vmware            |
 | SP4VE – Hyper-V             | sp-client-hyperv            |
 | SP4DB – Oracle              | sp-client-oracle            |
 | SP4DB – SQL                 | sp-client-sql               |
 | SP4Mail – Exchange          | sp-client-exchange          |
 | SP4Mail – Domino            | sp-client-domino            |
-| SP4ERP – SAP HANA           | sp-client-erp-sap-hana      |
-| SP4ERP – DB2                | sp-client-erp-db2           |
-| SP4ERP – Oracle             | sp-client-erp-oracle        |
+| SP4ERP – SAP HANA           | sp-client-sap-hana      |
+| SP4ERP – DB2                | sp-client-sap-db2           |
+| SP4ERP – Oracle             | sp-client-sap-oracle        |
 
 
 #### Each product directory contains its own script and a product-specific README that describes the modules applicable to that product.

--- a/must-gather/common/modules/env.pm
+++ b/must-gather/common/modules/env.pm
@@ -4,7 +4,7 @@ use warnings;
 use Exporter 'import';
 use File::Spec;
 
-our @EXPORT_OK = qw(_os get_ba_base_path get_server_address get_hyperv_base_path get_sql_base_path get_oracle_base_path get_sap_oracle_base_path get_api_base_path get_domino_base_path get_vmware_base_path get_exchange_base_path get_sap_db2_base_path);
+our @EXPORT_OK = qw(_os get_ba_base_path get_server_address get_hyperv_base_path get_sql_base_path get_oracle_base_path get_sap_oracle_base_path get_api_base_path get_domino_base_path get_vmware_base_path get_exchange_base_path get_sap_db2_base_path get_hsm_base_path);
 
 ###############################################################################
 # _os
@@ -782,5 +782,86 @@ sub get_sap_db2_base_path {
     # 3. Not found
     return undef;
 }
+# -----------------------------
+# get_hsm_base_path
+#
+# Purpose  : Determine IBM Spectrum Protect HSM client installation directory.
+# Input    : None
+# Output   : Absolute path to HSM bin directory, or undef if not found.
+# Behavior :
+#   1. Check HSM_DIR environment variable (highest priority).
+#   2. Fallback to OS-specific default install paths.
+#   3. For Windows: Check registry keys.
+#   4. For Unix/Linux: Check standard installation paths.
+# -----------------------------
+sub get_hsm_base_path {
+    my $os = _os();
+
+    # 1. Environment override
+    if ($ENV{HSM_DIR} && -d $ENV{HSM_DIR}) {
+        return $ENV{HSM_DIR};
+    }
+
+    # 2. Windows-specific paths
+    if ($os =~ /MSWin32/i) {
+        # Check registry for HSM installation
+        my @reg_keys = (
+            "HKLM\\SOFTWARE\\IBM\\ADSM\\CurrentVersion\\HSM",
+            "HKLM\\SOFTWARE\\WOW6432Node\\IBM\\ADSM\\CurrentVersion\\HSM",
+            "HKLM\\SOFTWARE\\IBM\\Tivoli\\TSM\\HSM",
+            "HKLM\\SOFTWARE\\WOW6432Node\\IBM\\Tivoli\\TSM\\HSM"
+        );
+        
+        foreach my $key (@reg_keys) {
+            my $cmd = qq{reg query "$key" /v Path 2>NUL};
+            my $out = `$cmd`;
+            if ($out =~ /Path\s+REG_\w+\s+([^\r\n]+)/i) {
+                my $path = $1;
+                $path =~ s/^\s+|\s+$//g;
+            return $path if -d $path;
+        }
+    }
+
+        # Fallback to common Windows paths
+        foreach my $path (
+            "C:/Program Files/Tivoli/TSM/HSMClient",
+            "C:/Program Files (x86)/Tivoli/TSM/HSMClient",
+            "C:/Program Files/Tivoli/TSM/HSM",
+            "C:/Program Files (x86)/Tivoli/TSM/HSM"
+        ) {
+            return $path if -d $path;
+        }
+    }
+    # 3. Unix/Linux/AIX/Solaris paths
+    elsif ($os =~ /linux/i) {
+        foreach my $path (
+            "/opt/tivoli/tsm/client/hsm/bin",
+            "/opt/tivoli/tsm/HSMClient"
+        ) {
+            return $path if -d $path;
+        }
+    }
+    elsif ($os =~ /aix/i) {
+        foreach my $path (
+            "/usr/tivoli/tsm/client/hsm/bin64",
+            "/usr/tivoli/tsm/client/hsm/bin",
+            "/usr/tivoli/tsm/HSMClient"
+        ) {
+            return $path if -d $path;
+        }
+    }
+    elsif ($os =~ /sunos|solaris/i) {
+        foreach my $path (
+            "/opt/tivoli/tsm/client/hsm/bin",
+            "/opt/tivoli/tsm/HSMClient"
+        ) {
+            return $path if -d $path;
+        }
+    }
+
+    # 4. Not found
+    return undef;
+}
+
 
 1;

--- a/must-gather/mustgather.pl
+++ b/must-gather/mustgather.pl
@@ -8,8 +8,6 @@ use lib "$FindBin::Bin/common/modules";
 use utils;
 use File::Spec;
 
-
-
 # ----------------------------------
 # Parameters
 # ----------------------------------
@@ -57,6 +55,7 @@ if ($help) {
         'sp-client-sap-hana'   => 1,
         'sp-client-sap-oracle' =>1,  
         'sp-client-sap-db2'   => 1,
+        'sp-client-hsm'   => 1, 
     );
 
     unless (exists $valid_products{$product}) {
@@ -228,6 +227,7 @@ print "Starting must-gather for product: $product\n" if $verbose;
         'sp-client-vmware' => "$FindBin::Bin/sp-client-vmware/mustgather.pl",
         'sp-client-sap-oracle'=> "$FindBin::Bin/sp-client-sap-oracle/mustgather.pl",
         'sp-client-sap-db2'=> "$FindBin::Bin/sp-client-sap-db2/mustgather.pl",
+        'sp-client-hsm' => "$FindBin::Bin/sp-client-hsm/mustgather.pl",
         # Add more products as developed
     );
 
@@ -280,7 +280,7 @@ sub print_usage {
 Usage: mustgather.pl --product <name> --output-dir <path> --caseno <case_number> --adminid <admin_id> [options]
 
 Mandatory:
-  --product, -p      Product name (sp-client-ba, sp-client-vmware, sp-client-sql, sp-server, sp-client-hyperv, sp-client-oracle, sp-client-exchange, sp-client-domino, sp-client-sap-hana , sp-client-sap-oracle, sp-client-sap-db2)
+  --product, -p      Product name (sp-client-ba, sp-client-vmware, sp-client-sql, sp-server, sp-client-hyperv, sp-client-oracle, sp-client-exchange, sp-client-domino, sp-client-sap-hana , sp-client-sap-oracle, sp-client-sap-db2, sp-client-hsm)
   --output-dir, -o   Target folder for collected data
   --caseno, -c       IBM Support Case Number (format: TS followed by 9 digits, e.g., TS020757841)
   --adminid, -id     Storage Protect server admin ID (password prompted securely)

--- a/must-gather/sp-client-hsm/README.md
+++ b/must-gather/sp-client-hsm/README.md
@@ -1,0 +1,69 @@
+# Must-Gather Scripts for IBM Spectrum Protect HSM Client
+
+# sp-client-hsm
+## Overview
+These scripts collect system, network, configuration, logs, and HSM-specific diagnostic data for IBM Spectrum Protect HSM clients.
+
+## Tested Platforms
+- Linux 
+- Windows
+
+## Prerequisites
+- Perl 5.x installed
+- Sudo privileges for network/firewall commands (Linux/AIX/Solaris)
+- IBM Spectrum Protect HSM Client must be installed on the system
+- Output directory must have write permissions
+
+## How to Run
+### Basic Command
+```bash
+perl mustgather.pl --product sp-client-hsm --output-dir <target_path> --adminid <id> --caseno <case_number> [options]
+```
+
+## Mandatory Parameters
+
+- `--product, -p` : Product name (`sp-client-hsm`)
+- `--output-dir, -o` : Target folder for collected data
+- `--adminid, -id` : Storage Protect server admin ID (password prompted securely)
+- `--caseno, -c` : IBM Support Case Number (format: TS followed by 9 digits, e.g., TS020757841)
+
+## Optional Parameters
+
+- `--modules, -m` : Comma-separated list of modules to collect (default: all)
+- `--optfile` : Path to Storage Protect options file
+- `--no-compress` : Disable output compression
+- `--verbose, -v` : Print detailed logs
+- `--help, -h` : Display usage
+
+## Example
+```bash
+perl mustgather.pl --product sp-client-hsm --output-dir /tmp/mustgather_output --adminid admin --caseno TS020757841 --verbose
+```
+
+## Data Collection Modules
+
+- `system` : Collects system information, OS details, and environment variables.
+
+- `network` : Performs network checks including ping, port check, firewall rules, and tcpdump capture.
+
+- `server` : Runs Storage Protect administrative queries for system, storage, logs, and server status.
+
+- `config` : Collects IBM Storage Protect configuration files (`dsm.opt`, `dsm.sys`, `dsminfo.txt`).
+
+- `logs` : Gathers client logs such as `dsmj.log`, `dsminstr.log`, `dsmwebcl.log`, `dsmerror.log`, `dsmsched.log`.
+
+- `hsm` : Collects HSM-specific data including:
+  - HSM system information (dsmc query systeminfo with HSM optfile)
+  - **Windows-specific commands:**
+    - dsminfo.exe all (complete HSM information)
+    - dsmhsmclc.exe -query (HSM client configuration)
+    - dsmhsmclc.exe check (HSM client status check)
+    - dsmclc.exe listfilespaces (HSM file spaces)
+  - **Unix/Linux-specific commands:**
+    - dsmmigfs queries (file system migration details)
+    - dsmdf (disk space information)
+    - dsmmigquery (HSM options and management)
+    - SpaceMan configuration directory listing
+  - HSM service/process status (OS-specific)
+  - HSM registry information (Windows only)
+

--- a/must-gather/sp-client-hsm/collector/hsm.pl
+++ b/must-gather/sp-client-hsm/collector/hsm.pl
@@ -1,0 +1,355 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use File::Path qw(make_path);
+use File::Basename;
+use FindBin;
+use lib "$FindBin::Bin/../../common/modules";
+use env;
+use Getopt::Long;
+
+# ===============================================================
+# Script Name : hsm.pl
+# Description : Collects HSM-specific diagnostic data for
+#               IBM Spectrum Protect HSM Client (Unix/Linux)
+#               Based on IBM technote collect.pl script
+# ===============================================================
+
+# -----------------------------
+# Parse command-line arguments
+# -----------------------------
+my ($output_dir, $verbose);
+GetOptions(
+    "output-dir|o=s" => \$output_dir,
+    "verbose|v"      => \$verbose,
+) or die "Invalid arguments. Run with --help for usage.\n";
+
+die "Error: --output-dir is required\n" unless $output_dir;
+
+# -----------------------------
+# Prepare output directory
+# -----------------------------
+$output_dir = "$output_dir/hsm";
+make_path($output_dir) unless -d $output_dir;
+
+# -----------------------------
+# Get base path using env.pm
+# -----------------------------
+my $hsm_path = env::get_hsm_base_path();
+my $os = env::_os();
+
+# -----------------------------
+# Error log setup
+# -----------------------------
+my $error_log = "$output_dir/script.log";
+open(my $errfh, '>', $error_log) or die "Cannot open $error_log: $!";
+
+print $errfh "=== Starting HSM-Specific Data Collection ===\n";
+print $errfh "Detected OS: $os\n";
+print $errfh "HSM Base Path: " . ($hsm_path || "NOT FOUND") . "\n\n";
+
+# -----------------------------
+# Collected items tracking
+# -----------------------------
+my %collected_items;
+
+# -----------------------------
+# Helper Functions
+# -----------------------------
+
+# Helper to run command and save output
+sub run_command_to_file {
+    my ($cmd, $output_file, $item_name) = @_;
+    
+    print $errfh "Executing: $cmd\n" if $verbose;
+    my $status = system("$cmd > \"$output_file\" 2>&1");
+    $status >>= 8;
+    
+    if ($status == 0 && -s $output_file) {
+        $collected_items{$item_name} = "Success";
+        print $errfh "Collected $item_name\n";
+    } else {
+        $collected_items{$item_name} = "Failed";
+        print $errfh "Warning: $item_name collection failed (exit code: $status)\n";
+    }
+}
+
+# ===============================================================
+# HSM SPECIFIC INFORMATION COLLECTION
+# Based on section 1.7 from IBM technote collect.pl
+# ===============================================================
+
+print $errfh "\n=== HSM Specific Information Collection ===\n";
+
+# -----------------------------------------------------------
+# 1. Check if HSM is installed using dsmmigquery
+# -----------------------------------------------------------
+my $hsm_check_file = "$output_dir/hsm_check.txt";
+my $hsm_check_cmd;
+
+if ($os =~ /MSWin32/i) {
+    $hsm_check_cmd = "\"$hsm_path\\dsminfo.exe\" all";
+}
+else {
+    $hsm_check_cmd = 'dsmmigquery 2>&1';
+}
+
+run_command_to_file(
+    $hsm_check_cmd,
+    $hsm_check_file,
+    "HSM_Check"
+);
+
+# Check if HSM is actually installed
+my $hsm_installed = 0;
+if (-f $hsm_check_file) {
+    open my $fh, '<', $hsm_check_file;
+    my $content = do { local $/; <$fh> };
+    close $fh;
+    
+    # If command not found or returns specific error codes, HSM is not installed
+    if ($content !~ /command not found/i && $content !~ /not recognized/i) {
+        $hsm_installed = 1;
+    }
+}
+
+if (!$hsm_installed) {
+    print $errfh "HSM does not appear to be installed on this system\n";
+    $collected_items{"HSM_Installation"} = "NOT FOUND";
+    
+    close($errfh);
+    
+    if ($verbose) {
+        print "\n=== HSM Module Summary ===\n";
+        print "HSM is not installed on this system\n";
+    }
+    
+    exit 1;
+}
+
+print $errfh "HSM is installed, proceeding with data collection...\n";
+
+# -----------------------------------------------------------
+# 2. dsmc query systeminfo with HSM optfile
+# Collect system information using HSM client configuration
+# -----------------------------------------------------------
+my $ba_path = env::get_ba_base_path();
+my $dsmc;
+
+if ($os =~ /MSWin32/i) {
+    $dsmc = `where dsmc.exe 2>nul`;
+    chomp($dsmc);
+    if (!$dsmc || !-e $dsmc) {
+        $dsmc = "$ba_path\\dsmc.exe" if -e "$ba_path\\dsmc.exe";
+    }
+} else {
+    $dsmc = `which dsmc 2>/dev/null`;
+    chomp($dsmc);
+    if (!$dsmc || !-x $dsmc) {
+        $dsmc = "$ba_path/dsmc" if -x "$ba_path/dsmc";
+    }
+}
+
+unless ($dsmc && -x $dsmc) {
+    print $errfh "Error: dsmc not found on this system.\n";
+    close($errfh);
+    die "Error: dsmc binary not found.\n";
+}
+# -----------------------------
+# Run DSM query for system info
+# -----------------------------
+my $cmd;
+my $console_out = "$output_dir/hsmsysteminfo_console.txt";
+my $opt_file= "$hsm_path/dsm.opt";
+my $systeminfo_file = "$output_dir/hsmsysteminfo.txt";
+if ($os =~ /MSWin32/i) {
+    $cmd = "\"$dsmc\" query systeminfo -filename=\"$systeminfo_file\" -optfile=\"$opt_file\"  >\"$console_out\" 2>&1";
+} else {
+    $cmd = "\"$dsmc\" query systeminfo -filename=\"$systeminfo_file\" -optfile=\"$opt_file\" >\"$console_out\" 2>&1";
+}
+
+# -----------------------------------------------------------
+# Platform-specific HSM commands
+# -----------------------------------------------------------
+if ($os =~ /MSWin32/i) {
+    # Windows-specific HSM commands
+    print $errfh "\n=== Collecting Windows HSM Information ===\n";
+    
+    # 3. dsminfo.exe all
+    # Collect all HSM information
+    run_command_to_file(
+        "\"$hsm_path\\dsminfo.exe\" all",
+        "$output_dir/hsminfo.txt",
+        "HSM_Info"
+    );
+    
+    # 4. dsmhsmclc.exe -query
+    # Query HSM client configuration
+    run_command_to_file(
+         "\"$hsm_path\\dsmhsmclc.exe\" -query",
+        "$output_dir/dsmhsmclc.txt",
+        "HSM_Client_Query"
+    );
+    
+    # 5. dsmhsmclc.exe check
+    # Check HSM client status
+    run_command_to_file(
+        "\"$hsm_path\\dsmhsmclc.exe\" check",
+        "$output_dir/dsmhsmclc_check.txt",
+        "HSM_Client_Check"
+    );
+    
+    # 6. dsmclc.exe listfilespaces
+    # List HSM file spaces
+    run_command_to_file(
+        "\"$hsm_path\\dsmclc.exe\" listfilespaces",
+        "$output_dir/hsmfilespaces.txt",
+        "HSM_Filespaces"
+    );
+    
+} else {
+    # Unix/Linux-specific HSM commands
+    print $errfh "\n=== Collecting Unix/Linux HSM Information ===\n";
+    
+    # 3. dsmmigfs q -detail
+    # Query file system migration details
+    run_command_to_file(
+        'dsmmigfs q -detail 2>&1',
+        "$output_dir/dsmmigfs_q_detail.txt",
+        "dsmmigfs_q_detail"
+    );
+    
+    # 4. dsmmigfs q -f
+    # Query file system migration with full details
+    run_command_to_file(
+        'dsmmigfs q -f 2>&1',
+        "$output_dir/dsmmigfs_q_f.txt",
+        "dsmmigfs_q_f"
+    );
+    
+    # 5. dsmdf
+    # Display HSM disk space information
+    run_command_to_file(
+        'dsmdf 2>&1',
+        "$output_dir/dsmdf.txt",
+        "dsmdf"
+    );
+    
+    # 6. ls -lR /etc/adsm/SpaceMan
+    # List HSM SpaceMan configuration directory
+    if (-d "/etc/adsm/SpaceMan") {
+
+    run_command_to_file(
+        'ls -lR /etc/adsm/SpaceMan',
+        "$output_dir/spaceman_config.txt",
+        "SpaceMan_Config"
+    );
+}
+else {
+    $collected_items{"SpaceMan_Config"} = "Not Found";
+}
+    
+    # 7. dsmmigquery -o
+    # Query HSM options
+    run_command_to_file(
+        'dsmmigquery -o 2>&1',
+        "$output_dir/dsmmigquery_o.txt",
+        "dsmmigquery_options"
+    );
+    
+    # 8. dsmmigquery -mgmt -detail
+    # Query HSM management details
+    run_command_to_file(
+        'dsmmigquery -mgmt -detail 2>&1',
+        "$output_dir/dsmmigquery_mgmt_detail.txt",
+        "dsmmigquery_mgmt"
+    );
+}
+
+# -----------------------------------------------------------
+# 9. HSM Processes (OS-specific)
+# -----------------------------------------------------------
+if ($os =~ /MSWin32/i) {
+    run_command_to_file(
+        'tasklist /FI "IMAGENAME eq dsm*" 2>&1',
+        "$output_dir/hsm_processes.txt",
+        "HSM_Processes"
+    );
+} else {
+    run_command_to_file(
+        'ps -ef | grep -i hsm | grep -v grep 2>&1',
+        "$output_dir/hsm_processes.txt",
+        "HSM_Processes"
+    );
+}
+
+# -----------------------------------------------------------
+# 10. HSM Daemons/Services (OS-specific)
+# -----------------------------------------------------------
+if ($os =~ /MSWin32/i) {
+    run_command_to_file(
+        'sc query state= all | findstr /i "hsm dsm" 2>&1',
+        "$output_dir/hsm_services.txt",
+        "HSM_Services"
+    );
+} elsif ($os =~ /linux/i) {
+    run_command_to_file(
+        'systemctl list-units | grep -i hsm 2>&1',
+        "$output_dir/hsm_services.txt",
+        "HSM_Services"
+    );
+} elsif ($os =~ /aix/i) {
+    run_command_to_file(
+        'lssrc -a | grep -i hsm 2>&1',
+        "$output_dir/hsm_services.txt",
+        "HSM_Services"
+    );
+} 
+
+
+# -----------------------------------------------------------
+# 11. HSM Environment Variables
+# -----------------------------------------------------------
+
+# Registry information
+if ($os =~ /MSWin32/i) {
+    run_command_to_file(
+        'reg query "HKEY_LOCAL_MACHINE\SOFTWARE\IBM\ADSM\CurrentVersion\HsmClient" /s',
+        "$output_dir/hsm_reg.txt",
+        "HSM_Registry"
+    );
+}
+
+
+# ===============================================================
+# SUMMARY
+# ===============================================================
+close($errfh);
+
+if ($verbose) {
+    print "\n=== HSM Module Summary ===\n";
+    foreach my $item (sort keys %collected_items) {
+        printf "  %-30s : %s\n", $item, $collected_items{$item};
+    }
+    print "\nCollected data saved in: $output_dir\n";
+    print "Check script.log for detailed information.\n";
+}
+
+# -----------------------------
+# Determine exit code
+# -----------------------------
+my $success_count = grep { $collected_items{$_} eq "Success" } keys %collected_items;
+my $total = scalar keys %collected_items;
+my $exit_code;
+
+if ($success_count == 0) {
+    $exit_code = 1;  # Complete failure
+} elsif ($success_count == $total) {
+    $exit_code = 0;  # Complete success
+} else {
+    $exit_code = 2;  # Partial success
+}
+
+exit($exit_code);
+
+# Made with Bob

--- a/must-gather/sp-client-hsm/collector/hsm.pl
+++ b/must-gather/sp-client-hsm/collector/hsm.pl
@@ -206,6 +206,14 @@ if ($os =~ /MSWin32/i) {
         "$output_dir/hsmfilespaces.txt",
         "HSM_Filespaces"
     );
+
+    system("xcopy \"$hsm_path\\logs\" \"$output_dir\\logs\" /E /I /Y >nul 2>&1");
+
+    if (-d "$output_dir/logs") {
+        $collected_items{"HSM_Logs"} = "Success";
+    } else {
+        $collected_items{"HSM_Logs"} = "Failed";
+    }
     
 } else {
     # Unix/Linux-specific HSM commands

--- a/must-gather/sp-client-hsm/mustgather.pl
+++ b/must-gather/sp-client-hsm/mustgather.pl
@@ -1,0 +1,165 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Getopt::Long;
+use File::Path qw(make_path);
+use Cwd 'abs_path';
+use FindBin;
+use lib "$FindBin::Bin/../common/modules";
+use utils;
+use File::Spec;
+use env;
+
+# ----------------------------------
+# Parameters
+# ----------------------------------
+my ($product, $output_dir, $optfile, $modules, $no_compress, $verbose, $help);
+
+GetOptions(
+    "product|p=s"       => \$product,
+    "output-dir|o=s"    => \$output_dir,
+    "optfile=s"         => \$optfile,
+    "modules|m=s"       => \$modules,
+    "no-compress"       => \$no_compress,
+    "verbose|v"         => \$verbose,
+    "help|h"            => \$help,
+) or die "Invalid arguments. Run with --help for usage.\n";
+
+# SECURITY: Get credentials from ENVIRONMENT only
+my $adminid  = $ENV{MUSTGATHER_ADMINID}  || '';
+my $password = $ENV{MUSTGATHER_PASSWORD} || '';
+
+if (!$help) {
+    die "Error: --product is mandatory\n"    unless defined $product;
+    die "Error: --output-dir is mandatory\n" unless defined $output_dir;
+}
+
+# ----------------------------------
+# Verify product installation
+# ----------------------------------
+my $hsm_path = env::get_hsm_base_path();
+unless ($hsm_path) {
+    die "Product '$product' is not installed on this machine.\n";
+}
+
+# Also get BA client path for server queries
+my $base_path = env::get_ba_base_path();
+
+my $os = env::_os();
+
+# ----------------------------------
+# Module List
+# ----------------------------------
+my @all_modules      = qw(system network config logs server hsm);
+my @selected_modules = $modules ? split /,/, $modules : @all_modules;
+
+print "\n############## Starting Collection of $product diagnostic information ##############\n\n";
+print "Modules to be collected (" . scalar(@selected_modules) . "): @selected_modules\n\n"
+    if $verbose;
+
+# ----------------------------------
+# Detect Server Address and TCP Port
+# ----------------------------------
+my $opt_file = $optfile ? $optfile : ($base_path ? "$base_path/dsm.opt" : undef);
+my $server_ip;
+my $port;
+
+if ($opt_file && grep { $_ eq "network" } @selected_modules) {
+    $server_ip = utils::get_server_address($opt_file, $base_path, $os) if $base_path;
+}
+
+$port = utils::get_tcp_port($opt_file, $base_path, $os) if $opt_file && $base_path;
+
+# ----------------------------------
+# Run Modules
+# ----------------------------------
+my %module_status;
+my $total = scalar @selected_modules;
+my $count = 0;
+
+foreach my $module (@selected_modules) {
+    $count++;
+    print "Running module ($count/$total): $module\n" if $verbose;
+
+    my $script;
+    if    ($module eq "system")      { $script = "$FindBin::Bin/../common/scripts/system_info.pl"; }
+    elsif ($module eq "network")     { $script = "$FindBin::Bin/../common/scripts/network_info.pl"; }
+    elsif ($module eq "config")      { $script = "$FindBin::Bin/../sp-client-ba/collector/config.pl"; }
+    elsif ($module eq "logs")        { $script = "$FindBin::Bin/../sp-client-ba/collector/log.pl"; }
+    elsif ($module eq "server")      { $script = "$FindBin::Bin/../common/scripts/server_info.pl"; }
+    elsif ($module eq "hsm")         { $script = "$FindBin::Bin/collector/hsm.pl"; }
+    else {
+        $module_status{$module} = "SKIPPED";
+        next;
+    }
+
+    my @args = ("perl", $script, "-o", $output_dir);
+    push @args, ("-s", $server_ip) if $module eq "network" && $server_ip;
+    push @args, ("-p", $port)      if $module eq "network" && $port;
+    push @args, "-v"               if $verbose;
+    push @args, ("--optfile", $optfile)
+        if $optfile && ($module eq "config" || $module eq "server");
+
+    my $exit_code = system(@args) >> 8;
+    $module_status{$module} =
+          $exit_code == 0 ? "Success"
+        : $exit_code == 2 ? "Partial"
+        :                   "Failed";
+}
+
+# ----------------------------------
+# Extract Product Info
+# ----------------------------------
+my $product_version = "Unknown";
+my $node_name       = "Unknown";
+my $server_name     = "Unknown";
+
+# Try to get version from HSM
+my $dsminfo_path = "$output_dir/config/dsminfo.txt";
+if (-e $dsminfo_path && open(my $fh, '<', $dsminfo_path)) {
+    while (<$fh>) {
+        if (/Client\s+Version\s+(.+)/i) {
+            $product_version = $1;
+            $product_version =~ s/\s+$//;
+        }
+    }
+    close $fh;
+}
+
+my $console_file = "$output_dir/config/systeminfo_console.txt";
+if (-e $console_file && open(my $fh, '<', $console_file)) {
+    while (<$fh>) {
+        if (/Node Name:\s*(\S+)/i) {
+            $node_name = $1;
+        }
+        elsif (/Session established with server\s+(\S+):/i) {
+            $server_name = $1;
+        }
+    }
+    close $fh;
+}
+unlink $console_file if -e $console_file;
+
+# ----------------------------------
+# Summary
+# ----------------------------------
+print "\n=== Must-Gather Collection Summary ===\n";
+printf "%-20s : %s\n", "Product",     $product;
+printf "%-20s : %s\n", "Version",     $product_version;
+printf "%-20s : %s\n", "Node Name",   $node_name;
+printf "%-20s : %s\n", "Server Name", $server_name;
+
+print "\n    Modules         : Status\n";
+print "-----------------------------\n";
+
+my $index = 1;
+foreach my $module (sort { lc($a) cmp lc($b) } @selected_modules) {
+    my $status = $module_status{$module} // "Not collected";
+    printf " %d. %-15s : %s\n", $index++, $module, $status;
+}
+
+print "\nCheck script.log inside each module folder for detailed failures.\n\n";
+printf "%-5s : %s\n\n", "Output", "$output_dir.zip" unless $no_compress;
+printf "%-5s : %s\n\n", "Output", "$output_dir" if $no_compress;
+
+# Made with Bob


### PR DESCRIPTION
# Must-Gather Scripts for IBM Spectrum Protect HSM Client

# sp-client-hsm
## Overview
These scripts collect system, network, configuration, logs, and HSM-specific diagnostic data for IBM Spectrum Protect HSM clients.

## Data Collection Modules

- `system` : Collects system information, OS details, and environment variables.

- `network` : Performs network checks including ping, port check, firewall rules, and tcpdump capture.

- `server` : Runs Storage Protect administrative queries for system, storage, logs, and server status.

- `config` : Collects IBM Storage Protect configuration files (`dsm.opt`, `dsm.sys`, `dsminfo.txt`).

- `logs` : Gathers client logs such as `dsmj.log`, `dsminstr.log`, `dsmwebcl.log`, `dsmerror.log`, `dsmsched.log`.

- `hsm` : Collects HSM-specific data including:
  - HSM system information (dsmc query systeminfo with HSM optfile)
  - **Windows-specific commands:**
    - dsminfo.exe all (complete HSM information)
    - dsmhsmclc.exe -query (HSM client configuration)
    - dsmhsmclc.exe check (HSM client status check)
    - dsmclc.exe listfilespaces (HSM file spaces)
  - **Unix/Linux-specific commands:**
    - dsmmigfs queries (file system migration details)
    - dsmdf (disk space information)
    - dsmmigquery (HSM options and management)
    - SpaceMan configuration directory listing
  - HSM service/process status (OS-specific)
  - HSM registry information (Windows only)

Technote used:- https://www.ibm.com/support/pages/collecting-data-spectrum-protect-hsm-client-problems-unix#generalgather
https://www.ibm.com/support/pages/collecting-data-ibm%C2%AE-tivoli%C2%AE-storage-manager-hsm-windows%C2%AE?view=full

Result:-https://ibm.ent.box.com/folder/389512665416